### PR TITLE
Change BotW series theme IDs

### DIFF
--- a/themes/art.yaml
+++ b/themes/art.yaml
@@ -33,4 +33,4 @@ Zelda_Wind_Waker_Outset_Island:
 BotW_The_Great_Plateau:
 - https://www.mediafire.com/file/wsr7htcwsn6am7d/BotW_The_Great_Plateau.ddw/file
 BotW_Dueling_Peaks_Stable:
-- https://www.mediafire.com/file/cg1o0k52dr877r4/BotW_Dueling_Peaks_Stable.ddw/file
+- https://www.mediafire.com/file/c0i78wyb8grutvm/BotW_Dueling_Peaks_Stable.ddw/file

--- a/themes/art.yaml
+++ b/themes/art.yaml
@@ -30,7 +30,7 @@ Windows_Insider:
 - https://www.mediafire.com/file/rv8wjk8jmmdet72/Windows_Insider.ddw/file
 Zelda_Wind_Waker_Outset_Island:
 - https://www.mediafire.com/file/q18juc7ux86jflt/Zelda_Wind_Waker_Outset_Island.ddw/file
-The_Great_Plateau:
-- https://www.mediafire.com/file/clpxnroc18bw2vp/The_Great_Plateau.ddw/file
-Dueling_Peaks_Stable:
-- https://www.mediafire.com/file/uchg7s8m93kbnfg/Dueling_Peaks_Stable.ddw/file
+BotW_The_Great_Plateau:
+- https://www.mediafire.com/file/n2ie1ue3qin58ta/BotW_The_Great_Plateau.ddw/file
+BotW_Dueling_Peaks_Stable:
+- https://www.mediafire.com/file/cp1risydbfln56x/BotW_Dueling_Peaks_Stable.ddw/file

--- a/themes/art.yaml
+++ b/themes/art.yaml
@@ -31,6 +31,6 @@ Windows_Insider:
 Zelda_Wind_Waker_Outset_Island:
 - https://www.mediafire.com/file/q18juc7ux86jflt/Zelda_Wind_Waker_Outset_Island.ddw/file
 BotW_The_Great_Plateau:
-- https://www.mediafire.com/file/n2ie1ue3qin58ta/BotW_The_Great_Plateau.ddw/file
+- https://www.mediafire.com/file/wsr7htcwsn6am7d/BotW_The_Great_Plateau.ddw/file
 BotW_Dueling_Peaks_Stable:
-- https://www.mediafire.com/file/cp1risydbfln56x/BotW_Dueling_Peaks_Stable.ddw/file
+- https://www.mediafire.com/file/cg1o0k52dr877r4/BotW_Dueling_Peaks_Stable.ddw/file


### PR DESCRIPTION
I am making a series of themes from _The Legend of Zelda: Breath of the Wild_. I only submitted two themes but more have been made. I want to change IDs of existing themes (by adding a prefix "BotW - ") so that other users can locate the series more easily.